### PR TITLE
Fix duplicate entry in recipe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @agola11 @baskaryan @efriis @hinthornw @hwchase17
+* @agola11 @baskaryan @efriis @hinthornw @hwchase17 @pavelzw

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+*
+!/conda-forge.yml
+
+!/*/
+!/recipe/**
+!/.ci_support/**
+
+*.pyc

--- a/README.md
+++ b/README.md
@@ -152,4 +152,5 @@ Feedstock Maintainers
 * [@efriis](https://github.com/efriis/)
 * [@hinthornw](https://github.com/hinthornw/)
 * [@hwchase17](https://github.com/hwchase17/)
+* [@pavelzw](https://github.com/pavelzw/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,4 +5,5 @@ conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
 bot:
+  inspection: update-grayskull
   automerge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -110,7 +110,6 @@ about:
   summary: Community contributed LangChain integrations.
   doc_url: https://api.python.langchain.com/en/stable/community_api_reference.html
   dev_url: https://github.com/langchain-ai/langchain/tree/master/libs/community
-  summary: Community contributed LangChain integrations.
   license: MIT
   license_file: LICENSE
 
@@ -121,3 +120,4 @@ extra:
     - hwchase17
     - efriis
     - agola11
+    - pavelzw


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #4 
Closes #3 

Looking at the error-log of the autoupdater, we can see the following

```
8.00 attempts - The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!

Please check the URLs in your recipe with version '0.0.6' to make sure they exist!

We also found the following errors:

 - We found a problem parsing the recipe for version '0.0.6': 

DuplicateKeyError('while constructing a mapping',   in "", line 109, column 3:
      home: https://github.com/langcha ... 
      ^ (line: 109), 'found duplicate key "summary" with value "Community contributed LangChain integrations." (original value: "Community contributed LangChain integrations.")',   in "", line 113, column 3:
      summary: Community contributed L ... 
      ^ (line: 113), '\n                    To suppress this check see:\n                        http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys\n                    ', '                    Duplicate keys will become an error in future releases, and are errors\n                    by default when using the new API.\n                    ')

traceback:
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/update_recipe/version.py", line 411, in update_version
    cmeta = CondaMetaYAML(raw_meta_yaml)
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/recipe_parser/_parser.py", line 514, in __init__
    self.meta = self._parser.load("".join(lines))
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/main.py", line 451, in load
    return constructor.get_single_data()
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 114, in get_single_data
    return self.construct_document(node)
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 123, in construct_document
    for _dummy in generator:
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1470, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1359, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 145, in construct_object
    data = self.construct_non_recursive_object(node)
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 186, in construct_non_recursive_object
    for _dummy in generator:
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1470, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1360, in construct_mapping
    if self.check_mapping_key(node, key_node, maptyp, key, value):
  File "/home/runner/miniconda3/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 276, in check_mapping_key
    raise DuplicateKeyError(*args)
```
