### PR TITLE
Update python_max version constraint to <3.13

### DIFF
--- a/.ci_support/linux_64_python_min3.10.yaml
+++ b/.ci_support/linux_64_python_min3.10.yaml
@@ -4,11 +4,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.13.* *_cp313
 python_min:
 - '3.10'

--- a/.ci_support/linux_64_python_min3.12.yaml
+++ b/.ci_support/linux_64_python_min3.12.yaml
@@ -4,11 +4,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.13.* *_cp313
 python_min:
 - '3.12'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "langchain-community" %}
 {% set version = "0.3.31" %}
-{% set build = 1 %}
-{% set python_max = ",<3.12a0" if python_min == "3.10" else "" %}
+{% set build = 2 %}
+{% set python_max = ",<3.13" if python_min == "3.10" else "" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
The initial boundary was introduced in #84

My best interpretation of what is going on - upstream `langchain-community` has two sets of dependencies - it can either work on `python<3.13` with `numpy>=1.26.2` **or** with `python>=3.13` with `numpy>=2.1.0`

I believe this is **not** correctly expressed in the conda package (not sure if conda has the capabilities to express something like this) - because regardless of the version of python used - the numpy dependency will always be `>=1.62.2`. But with an upper boundary at least the conda package wouldn't be installable within the env with new python.

Regardless, the existing boundary of `<3.12a0` doesn't really make sense because `2.12.*` should work just fine, see how the boundary is (now) expressed in the upstream https://github.com/langchain-ai/langchain/blob/25d77aa8b4d257ecff49dd481c62197368b90735/libs/community/pyproject.toml#L21

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
